### PR TITLE
Update caliper.gemspec to fix homepage URL

### DIFF
--- a/caliper.gemspec
+++ b/caliper.gemspec
@@ -7,7 +7,7 @@ Gem::Specification.new do |g|
 	g.version     = Caliper::VERSION
 	g.authors     = ["Matthew Hogan", "Prashant Nayak", "Zhen Qian", "Anthony Whyte"]
 	g.email       = ["lmattson@imsglobal.org"]
-	g.homepage    = "https://github.com/IMSGlobal/caliper-ruby"
+	g.homepage    = "https://github.com/IMSGlobal/caliper-ruby-public"
 	g.summary     = "Caliper Sensor API"
 	g.description = "Ruby implementation of the IMS Caliper Sensor."
 	g.license     = "LGPL-3.0"


### PR DESCRIPTION
Hi, I found that homepage URL of `ims_caliper` gem is missing.

At https://rubygems.org/gems/ims_caliper, Homepage link is located to https://github.com/IMSGlobal/caliper-ruby, but this URL is not found.

I'm not sure if https://github.com/IMSGlobal/caliper-ruby-public is a valid URL as Homepage of gem, but since Source Code link is located to https://github.com/IMSGlobal/caliper-ruby-public, I propose to use same URL as Homepage.